### PR TITLE
Fix mobile menu and small-screen overflow

### DIFF
--- a/e2e/tests/frontend.spec.ts
+++ b/e2e/tests/frontend.spec.ts
@@ -68,16 +68,53 @@ test.describe('Navigation flow', () => {
     await expect(page).toHaveURL(/\/players/);
   });
 
-  test('mobile menu toggle opens sidebar', async ({ page }) => {
+  test('mobile menu toggle opens and closes sidebar', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await waitForShell(page);
-    await page.getByRole('button', { name: 'Open menu' }).click();
+
+    const openButton = page.getByRole('button', { name: 'Open menu' });
+    await openButton.click();
+    await expect(page.locator('html')).toHaveClass(/sidebar-enable/);
     await expect(page.locator('.main-nav')).toBeVisible();
+    await expect(page.locator('[data-ds-sidebar-backdrop]')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Close menu' }).click();
+    await expect(page.locator('html')).not.toHaveClass(/sidebar-enable/);
+    await expect(page.locator('[data-ds-sidebar-backdrop]')).toHaveCount(0);
   });
 
   test('mobile bottom nav is visible', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await waitForShell(page);
     await expect(page.locator('.ds-bottom-nav')).toBeVisible();
+  });
+
+  test('mobile viewport has no horizontal page overflow', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitForShell(page);
+
+    const metrics = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+      bodyScrollWidth: document.body.scrollWidth,
+    }));
+
+    expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
+    expect(metrics.bodyScrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
+  });
+
+  test('more menu stays anchored on small screens', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await waitForShell(page);
+    await page.getByRole('button', { name: 'More navigation' }).click();
+
+    const menu = page.locator('.ds-more-menu');
+    await expect(menu).toBeVisible();
+
+    const box = await menu.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(390 + 1);
   });
 });

--- a/resources/js/src/lib/assets/scss/components/_reboot.scss
+++ b/resources/js/src/lib/assets/scss/components/_reboot.scss
@@ -2,8 +2,13 @@
 // _reboot.scss
 //
 
+html {
+    overflow-x: clip;
+}
+
 body {
-    overflow-x: hidden;
+    overflow-x: clip;
+    max-width: 100%;
 }
 
 .row > * {

--- a/resources/js/src/lib/assets/scss/design-system/_components.scss
+++ b/resources/js/src/lib/assets/scss/design-system/_components.scss
@@ -13,9 +13,16 @@ body {
     max-width: var(--ds-container-max);
     margin: 0 auto;
     padding: 0 var(--ds-margin-mobile);
+    width: 100%;
+    box-sizing: border-box;
+    overflow-x: clip;
 
     @media (min-width: 768px) {
         padding: 0 var(--ds-margin-desktop);
+    }
+
+    .table-responsive {
+        max-width: 100%;
     }
 }
 
@@ -227,13 +234,16 @@ html[data-bs-theme='light'] {
 }
 
 .ds-score-card {
-    min-width: 280px;
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
     background: var(--ds-surface-container);
     border: 1px solid var(--ds-border-subtle);
     border-radius: var(--ds-radius-lg);
     padding: var(--ds-spacing-md);
     color: var(--ds-card-on-surface, var(--ds-on-surface));
     transition: transform 0.2s ease;
+    box-sizing: border-box;
 
     html[data-bs-theme='light'] & {
         background: var(--ds-surface-dark);
@@ -316,9 +326,17 @@ html[data-bs-theme='light'] {
     overflow-x: auto;
     padding-bottom: var(--ds-spacing-xs);
     scrollbar-width: none;
+    max-width: 100%;
+    -webkit-overflow-scrolling: touch;
 
     &::-webkit-scrollbar {
         display: none;
+    }
+
+    > .ds-score-card {
+        flex: 0 0 min(280px, calc(100vw - 48px));
+        width: min(280px, calc(100vw - 48px));
+        max-width: min(280px, calc(100vw - 48px));
     }
 }
 
@@ -356,10 +374,19 @@ html[data-bs-theme='light'] {
     background: var(--ds-surface-container-high) !important;
     border: 1px solid var(--ds-border-subtle) !important;
     border-radius: var(--ds-radius-lg) !important;
+    position: absolute !important;
+    right: 0 !important;
+    left: auto !important;
+    width: min(calc(100vw - 32px), 280px) !important;
+    max-width: calc(100vw - 32px);
+    max-height: min(70vh, 420px);
+    overflow-y: auto;
+    z-index: 1060;
 
     .dropdown-item {
         color: var(--ds-on-surface);
         font-size: 14px;
+        white-space: normal;
 
         &:hover {
             background: var(--ds-surface-dark-elevated);
@@ -373,6 +400,16 @@ html[data-bs-theme='light'] {
         font-weight: 700;
         letter-spacing: 0.08em;
         text-transform: uppercase;
+    }
+}
+
+.topbar.ds-topbar {
+    .dropdown {
+        position: relative;
+    }
+
+    .topbar-item {
+        position: relative;
     }
 }
 

--- a/resources/js/src/lib/assets/scss/design-system/_shell-overrides.scss
+++ b/resources/js/src/lib/assets/scss/design-system/_shell-overrides.scss
@@ -18,20 +18,17 @@
         transition: transform 0.25s ease;
         box-shadow: none;
         z-index: 1020;
-
-        @media (min-width: 1141px) {
+        // Match Bootstrap lg / hamburger (d-lg-none): drawer only below 992px
+        @media (min-width: 992px) {
             display: none !important;
         }
-    }
-
-    &.sidebar-open .main-nav {
-        transform: translateX(0);
     }
 
     .footer {
         margin-top: var(--ds-spacing-lg);
         padding: var(--ds-spacing-md) 0;
         font-size: 12px;
+        position: relative;
     }
 }
 
@@ -73,15 +70,23 @@ html.sidebar-enable .wrapper.ds-shell .main-nav {
 // Mobile bottom nav spacing
 @media (max-width: 767.98px) {
     .wrapper.ds-shell .page-content {
-        padding-bottom: calc(72px + var(--ds-spacing-md));
+        padding-bottom: calc(var(--ds-bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px) + var(--ds-spacing-md));
     }
+}
+
+// Keep shell content from forcing horizontal scroll on phones
+.wrapper.ds-shell {
+    max-width: 100%;
+    overflow-x: clip;
 }
 
 // Stitch segmented toggles (prediction-engine / league-standings pattern)
 .wrapper.ds-shell {
     .btn-group {
         display: flex;
+        flex-wrap: wrap;
         width: 100%;
+        max-width: 100%;
         padding: 4px;
         gap: 4px;
         background: var(--ds-surface-container);
@@ -94,6 +99,7 @@ html.sidebar-enable .wrapper.ds-shell .main-nav {
         > .btn:last-child,
         > .btn:not(:last-child):not(.dropdown-toggle) {
             flex: 1 1 0;
+            min-width: 0;
             margin: 0;
             border: none !important;
             border-radius: var(--ds-radius) !important;
@@ -102,9 +108,16 @@ html.sidebar-enable .wrapper.ds-shell .main-nav {
             letter-spacing: 0.06em;
             text-transform: uppercase;
             line-height: 1.2;
-            padding: 8px 16px;
+            padding: 8px 12px;
             box-shadow: none !important;
-            white-space: nowrap;
+            white-space: normal;
+            text-align: center;
+
+            @media (max-width: 479.98px) {
+                font-size: 11px;
+                padding: 8px;
+                letter-spacing: 0.04em;
+            }
         }
 
         > .btn-primary,

--- a/resources/js/src/lib/assets/scss/design-system/_shell-overrides.scss
+++ b/resources/js/src/lib/assets/scss/design-system/_shell-overrides.scss
@@ -34,6 +34,15 @@
 
 html.sidebar-enable .wrapper.ds-shell .main-nav {
     transform: translateX(0);
+    z-index: 1012;
+    box-shadow: 8px 0 24px rgba(0, 0, 0, 0.18);
+}
+
+// Mobile drawer backdrop must not cover the fixed topbar controls
+html.sidebar-enable [data-ds-sidebar-backdrop] {
+    z-index: 1010 !important;
+    top: var(--ds-topbar-height);
+    height: calc(100% - var(--ds-topbar-height));
 }
 
 // Kill legacy template shadows / light surfaces in dark shell
@@ -78,6 +87,42 @@ html.sidebar-enable .wrapper.ds-shell .main-nav {
 .wrapper.ds-shell {
     max-width: 100%;
     overflow-x: clip;
+
+    .page-title-box {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--ds-spacing-sm);
+        float: none;
+
+        .page-title-right {
+            float: none;
+            margin: 0;
+            order: -1;
+            width: 100%;
+
+            @media (min-width: 576px) {
+                order: 0;
+                width: auto;
+            }
+        }
+
+        .page-title {
+            width: 100%;
+            margin-bottom: 0;
+            word-break: break-word;
+        }
+    }
+
+    .input-group {
+        max-width: 100%;
+        flex-wrap: nowrap;
+
+        .form-control {
+            min-width: 0;
+        }
+    }
 }
 
 // Stitch segmented toggles (prediction-engine / league-standings pattern)

--- a/resources/js/src/lib/assets/scss/design-system/_tokens.scss
+++ b/resources/js/src/lib/assets/scss/design-system/_tokens.scss
@@ -26,6 +26,8 @@
     --ds-container-max: 1320px;
 
     --ds-topbar-height: 64px;
+    --ds-drawer-width: 260px;
+    --ds-bottom-nav-height: 64px;
 
     // Light fallback before layout JS hydrates (Stitch default shell)
     --ds-surface: #f9f9f9;

--- a/resources/js/src/lib/assets/scss/design-system/_topbar.scss
+++ b/resources/js/src/lib/assets/scss/design-system/_topbar.scss
@@ -32,7 +32,8 @@
 
     .navbar-header {
         height: 100%;
-        gap: var(--ds-spacing-md);
+        gap: var(--ds-spacing-sm);
+        align-items: center;
     }
 
     .ds-topbar__brand {
@@ -108,15 +109,50 @@
         align-items: center;
         gap: 4px;
         margin-left: auto;
+        height: 100%;
+        flex-shrink: 0;
+    }
+
+    .topbar-item {
+        height: auto !important;
+        align-self: center;
+    }
+
+    .topbar-item .nav-link,
+    .topbar-item .dropdown-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+        height: auto;
     }
 
     .topbar-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        padding: 0;
+        border: none;
+        border-radius: var(--ds-radius);
+        background: transparent;
         color: var(--ds-on-surface-variant);
+        line-height: 1;
+        appearance: none;
+        -webkit-appearance: none;
 
-        &:hover {
+        &:hover,
+        &:focus-visible {
             color: var(--ds-on-surface);
             background: var(--ds-surface-container-high);
         }
+    }
+
+    .navbar-header > .d-flex {
+        min-width: 0;
+        align-items: center;
+        height: 100%;
     }
 }
 
@@ -138,10 +174,32 @@
         max-width: min(var(--ds-drawer-width, 260px), 86vw);
         background: var(--ds-surface-container-low);
         border-right-color: var(--ds-border-subtle);
-        overflow-x: hidden;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        padding-bottom: 0;
 
         .logo-box {
             display: none;
+        }
+
+        // Logo is hidden in Stitch shell — use full drawer height for the menu
+        .scrollbar {
+            flex: 1 1 auto;
+            min-height: 0;
+            height: 100% !important;
+            max-height: none !important;
+            overflow-y: auto;
+            -webkit-overflow-scrolling: touch;
+            padding-bottom: calc(var(--ds-spacing-lg) + env(safe-area-inset-bottom, 0px));
+        }
+
+        .simplebar-wrapper,
+        .simplebar-mask,
+        .simplebar-offset,
+        .simplebar-content-wrapper {
+            height: 100% !important;
+            max-height: 100% !important;
         }
     }
 }

--- a/resources/js/src/lib/assets/scss/design-system/_topbar.scss
+++ b/resources/js/src/lib/assets/scss/design-system/_topbar.scss
@@ -125,14 +125,20 @@
         padding-top: calc(var(--ds-topbar-height) + var(--ds-spacing-md));
         margin-left: 0;
         padding-left: 0;
-        min-height: 100vh;
+        min-height: 100dvh;
+        overflow-x: clip;
+        max-width: 100%;
     }
 
     .main-nav {
         top: var(--ds-topbar-height);
-        height: calc(100vh - var(--ds-topbar-height));
+        height: calc(100dvh - var(--ds-topbar-height));
+        width: min(var(--ds-drawer-width, 260px), 86vw);
+        min-width: 0;
+        max-width: min(var(--ds-drawer-width, 260px), 86vw);
         background: var(--ds-surface-container-low);
         border-right-color: var(--ds-border-subtle);
+        overflow-x: hidden;
 
         .logo-box {
             display: none;

--- a/resources/js/src/lib/assets/scss/structure/_topbar.scss
+++ b/resources/js/src/lib/assets/scss/structure/_topbar.scss
@@ -129,7 +129,8 @@ html[data-menu-size='hidden'] {
 }
 
 @media (max-width: 600px) {
-    .topbar {
+    // Legacy admin topbar only — Stitch shell keeps anchored menus
+    .topbar:not(.ds-topbar) {
         .dropdown {
             position: static;
 

--- a/resources/js/src/lib/components/DashboardHome.svelte
+++ b/resources/js/src/lib/components/DashboardHome.svelte
@@ -434,8 +434,14 @@
     }
     .ds-hero__stats {
         display: flex;
-        gap: var(--ds-spacing-xl);
+        flex-wrap: wrap;
+        gap: var(--ds-spacing-md);
         margin-top: var(--ds-spacing-md);
+    }
+    @media (min-width: 480px) {
+        .ds-hero__stats {
+            gap: var(--ds-spacing-xl);
+        }
     }
     .ds-hero__stats > div { display: flex; flex-direction: column; gap: 4px; }
     .ds-hero__stat {
@@ -490,7 +496,7 @@
     .ds-leader-avatar--placeholder { display: inline-block; }
     .ds-accuracy-grid {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
         gap: var(--ds-spacing-sm);
     }
     .ds-accuracy-grid .ds-score-card {

--- a/resources/js/src/lib/components/ErrorMessage.svelte
+++ b/resources/js/src/lib/components/ErrorMessage.svelte
@@ -2,17 +2,42 @@
     export let message: string;
 </script>
 
-<div class="bg-red-50 border-l-4 border-red-400 p-4">
-    <div class="flex">
-        <div class="flex-shrink-0">
-            <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
-            </svg>
-        </div>
-        <div class="ml-3">
-            <p class="text-sm text-red-700">
-                {message}
-            </p>
-        </div>
+<div class="alert alert-danger ds-error-message" role="alert" data-testid="error-container">
+    <div class="ds-error-message__row">
+        <svg
+            class="ds-error-message__icon"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+            data-testid="error-icon"
+        >
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+        </svg>
+        <p class="ds-error-message__text mb-0">{message}</p>
     </div>
 </div>
+
+<style>
+    .ds-error-message {
+        max-width: 100%;
+    }
+
+    .ds-error-message__row {
+        display: flex;
+        align-items: flex-start;
+        gap: 0.75rem;
+    }
+
+    .ds-error-message__icon {
+        width: 1.25rem;
+        height: 1.25rem;
+        flex-shrink: 0;
+        margin-top: 0.1rem;
+    }
+
+    .ds-error-message__text {
+        min-width: 0;
+        word-break: break-word;
+        font-size: 0.875rem;
+    }
+</style>

--- a/resources/js/src/lib/components/__tests__/ErrorMessage.test.ts
+++ b/resources/js/src/lib/components/__tests__/ErrorMessage.test.ts
@@ -27,8 +27,9 @@ describe('ErrorMessage', () => {
         });
 
         const container = screen.getByTestId('error-container');
-        expect(container).toHaveClass('bg-red-50');
-        expect(container).toHaveClass('border-red-200');
+        expect(container).toHaveClass('alert');
+        expect(container).toHaveClass('alert-danger');
+        expect(container).toHaveClass('ds-error-message');
     });
 
     it('renders with long error message', () => {

--- a/resources/js/src/lib/components/ui/DsSearchInput.svelte
+++ b/resources/js/src/lib/components/ui/DsSearchInput.svelte
@@ -26,13 +26,14 @@
         max-width: 640px;
     }
 
-    .ds-search__icon {
+    .ds-search :global(.ds-search__icon) {
         position: absolute;
         left: 14px;
         top: 50%;
         transform: translateY(-50%);
         color: var(--ds-outline);
         pointer-events: none;
+        z-index: 1;
     }
 
     .ds-search__input {
@@ -45,6 +46,7 @@
         font-size: 14px;
         line-height: 21px;
         transition: border-color 0.15s ease;
+        box-sizing: border-box;
     }
 
     .ds-search__input:focus {

--- a/resources/js/src/lib/layouts/components/LeftSideBar.svelte
+++ b/resources/js/src/lib/layouts/components/LeftSideBar.svelte
@@ -5,7 +5,7 @@
     import 'simplebar'
 </script>
 
-<div class="main-nav">
+<div class="main-nav" id="ds-main-nav" aria-label="Site menu">
     <LogoBox/>
 
     <div data-simplebar class="scrollbar">

--- a/resources/js/src/lib/layouts/components/LeftSideBar.svelte
+++ b/resources/js/src/lib/layouts/components/LeftSideBar.svelte
@@ -2,13 +2,12 @@
     import LogoBox from "$lib/components/LogoBox.svelte";
     import AppMenu from "$lib/components/AppMenu/index.svelte"
     import {getMenuItems} from "$lib/helpers/menu";
-    import 'simplebar'
 </script>
 
 <div class="main-nav" id="ds-main-nav" aria-label="Site menu">
     <LogoBox/>
 
-    <div data-simplebar class="scrollbar">
+    <div class="scrollbar">
         <AppMenu menuItems={getMenuItems()}/>
     </div>
 </div>

--- a/resources/js/src/lib/layouts/components/MobileBottomNav.svelte
+++ b/resources/js/src/lib/layouts/components/MobileBottomNav.svelte
@@ -37,15 +37,19 @@
         z-index: 1010;
         display: flex;
         justify-content: space-around;
-        align-items: center;
-        height: 64px;
-        padding: 0 8px env(safe-area-inset-bottom);
+        align-items: stretch;
+        min-height: var(--ds-bottom-nav-height, 64px);
+        height: calc(var(--ds-bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px));
+        padding: 0 4px env(safe-area-inset-bottom, 0px);
         background: var(--ds-surface-container);
         border-top: 1px solid var(--ds-border-subtle);
+        box-sizing: border-box;
     }
 
     .ds-bottom-nav__item {
         display: flex;
+        flex: 1 1 0;
+        min-width: 0;
         flex-direction: column;
         align-items: center;
         justify-content: center;
@@ -56,9 +60,16 @@
         font-weight: 700;
         letter-spacing: 0.06em;
         text-transform: uppercase;
-        padding: 6px 12px;
+        padding: 6px 4px;
         border-radius: var(--ds-radius-pill);
         transition: color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+    }
+
+    .ds-bottom-nav__item span {
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .ds-bottom-nav__item.active {

--- a/resources/js/src/lib/layouts/components/MobileBottomNav.svelte
+++ b/resources/js/src/lib/layouts/components/MobileBottomNav.svelte
@@ -37,19 +37,26 @@
         z-index: 1010;
         display: flex;
         justify-content: space-around;
-        align-items: stretch;
+        align-items: center;
         min-height: var(--ds-bottom-nav-height, 64px);
         height: calc(var(--ds-bottom-nav-height, 64px) + env(safe-area-inset-bottom, 0px));
-        padding: 0 4px env(safe-area-inset-bottom, 0px);
+        padding: 6px 4px calc(6px + env(safe-area-inset-bottom, 0px));
         background: var(--ds-surface-container);
         border-top: 1px solid var(--ds-border-subtle);
         box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    :global(html.sidebar-enable) .ds-bottom-nav {
+        visibility: hidden;
+        pointer-events: none;
     }
 
     .ds-bottom-nav__item {
         display: flex;
         flex: 1 1 0;
         min-width: 0;
+        max-width: 96px;
         flex-direction: column;
         align-items: center;
         justify-content: center;
@@ -60,9 +67,10 @@
         font-weight: 700;
         letter-spacing: 0.06em;
         text-transform: uppercase;
-        padding: 6px 4px;
+        padding: 4px 6px;
+        margin: 0 2px;
         border-radius: var(--ds-radius-pill);
-        transition: color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+        transition: color 0.15s ease, background 0.15s ease;
     }
 
     .ds-bottom-nav__item span {
@@ -75,6 +83,5 @@
     .ds-bottom-nav__item.active {
         color: var(--ds-on-primary);
         background: var(--ds-secondary);
-        transform: translateY(-2px);
     }
 </style>

--- a/resources/js/src/lib/layouts/components/TopBar.svelte
+++ b/resources/js/src/lib/layouts/components/TopBar.svelte
@@ -12,9 +12,14 @@
         DropdownMenu,
         DropdownToggle
     } from '@sveltestrap/sveltestrap';
-    import {toggleDocumentAttribute} from "$lib/helpers/layout";
+    import { onDestroy, onMount } from 'svelte';
 
     export let onOpenThemeSettings: (() => void) | undefined = undefined;
+
+    const SIDEBAR_CLASS = 'sidebar-enable';
+    const BACKDROP_ATTR = 'data-ds-sidebar-backdrop';
+
+    let sidebarOpen = false;
 
     const moreLinks = MENU_ITEMS.flatMap((item) => {
         if (item.isTitle) return [];
@@ -27,23 +32,74 @@
         return [];
     });
 
+    function getBackdrop(): HTMLElement | null {
+        return document.querySelector(`[${BACKDROP_ATTR}]`);
+    }
+
+    function removeBackdrop() {
+        const existing = getBackdrop();
+        if (existing?.parentNode) {
+            existing.parentNode.removeChild(existing);
+        }
+        document.body.style.overflow = '';
+    }
+
+    function closeSidebar() {
+        document.documentElement.classList.remove(SIDEBAR_CLASS);
+        removeBackdrop();
+        sidebarOpen = false;
+    }
+
+    function openSidebar() {
+        document.documentElement.classList.add(SIDEBAR_CLASS);
+        if (!getBackdrop()) {
+            const backdrop = document.createElement('div');
+            backdrop.classList.add('offcanvas-backdrop', 'fade', 'show');
+            backdrop.setAttribute(BACKDROP_ATTR, 'true');
+            backdrop.addEventListener('click', closeSidebar);
+            document.body.appendChild(backdrop);
+            document.body.style.overflow = 'hidden';
+        }
+        sidebarOpen = true;
+    }
+
     const toggleLeftSideBar = () => {
-        toggleDocumentAttribute('class', 'sidebar-enable')
-        showBackdrop()
+        if (document.documentElement.classList.contains(SIDEBAR_CLASS)) {
+            closeSidebar();
+        } else {
+            openSidebar();
+        }
+    };
+
+    function handleKeydown(event: KeyboardEvent) {
+        if (event.key === 'Escape' && sidebarOpen) {
+            closeSidebar();
+        }
     }
 
-    const showBackdrop = () => {
-        const backdrop = document.createElement('div') as HTMLDivElement;
-        backdrop.classList.add('offcanvas-backdrop', 'fade', 'show')
-        document.body.appendChild(backdrop);
-        document.body.style.overflow = 'hidden';
-
-        backdrop.addEventListener('click', () => {
-            toggleDocumentAttribute('class', '')
-            document.body.removeChild(backdrop);
-            document.body.style.overflow = '';
-        })
+    function handleNavClick(event: MouseEvent) {
+        const target = event.target as HTMLElement | null;
+        if (target?.closest?.('.main-nav a')) {
+            closeSidebar();
+        }
     }
+
+    onMount(() => {
+        sidebarOpen = document.documentElement.classList.contains(SIDEBAR_CLASS);
+        document.addEventListener('keydown', handleKeydown);
+        document.addEventListener('click', handleNavClick);
+        return () => {
+            document.removeEventListener('keydown', handleKeydown);
+            document.removeEventListener('click', handleNavClick);
+            closeSidebar();
+        };
+    });
+
+    onDestroy(() => {
+        if (typeof document !== 'undefined') {
+            closeSidebar();
+        }
+    });
 
     function isActive(url: string, pathname: string): boolean {
         if (url === '/') return pathname === '/';
@@ -59,9 +115,11 @@
                     type="button"
                     class="topbar-button d-lg-none"
                     on:click={toggleLeftSideBar}
-                    aria-label="Open menu"
+                    aria-label={sidebarOpen ? 'Close menu' : 'Open menu'}
+                    aria-expanded={sidebarOpen}
+                    aria-controls="ds-main-nav"
                 >
-                    <DsIcon name="menu" size={22} />
+                    <DsIcon name={sidebarOpen ? 'close' : 'menu'} size={22} />
                 </button>
                 <div class="ds-topbar__brand">
                     <LogoBox logoSmHeight={28} logoLgHeight={32} />

--- a/resources/js/src/lib/layouts/components/TopBar.svelte
+++ b/resources/js/src/lib/layouts/components/TopBar.svelte
@@ -56,6 +56,8 @@
             const backdrop = document.createElement('div');
             backdrop.classList.add('offcanvas-backdrop', 'fade', 'show');
             backdrop.setAttribute(BACKDROP_ATTR, 'true');
+            // Sit above page content but below fixed topbar so the close control stays clickable
+            backdrop.style.zIndex = '1010';
             backdrop.addEventListener('click', closeSidebar);
             document.body.appendChild(backdrop);
             document.body.style.overflow = 'hidden';

--- a/resources/js/src/routes/players/+page.svelte
+++ b/resources/js/src/routes/players/+page.svelte
@@ -145,7 +145,7 @@
     }
     .ds-player-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(min(260px, 100%), 1fr));
         gap: var(--ds-spacing-md);
     }
     .ds-player-card {

--- a/resources/js/src/routes/players/+page.svelte
+++ b/resources/js/src/routes/players/+page.svelte
@@ -140,8 +140,22 @@
     }
     .ds-chip-row {
         display: flex;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         gap: var(--ds-spacing-sm);
+        overflow-x: auto;
+        max-width: 100%;
+        padding-bottom: 2px;
+        padding-right: 4px;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+        mask-image: linear-gradient(to right, #000 85%, transparent 100%);
+    }
+    .ds-chip-row::-webkit-scrollbar {
+        display: none;
+    }
+    .ds-chip-row :global(.ds-chip),
+    .ds-chip-row :global(button) {
+        flex: 0 0 auto;
     }
     .ds-player-grid {
         display: grid;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Repair the mobile hamburger drawer so it properly toggles open/closed without wiping `html` classes or stacking backdrops
- Stop the More menu from stretching full-width on phones (legacy topbar dropdown rule)
- Fix overflow sources: score-card min-width, segmented filter buttons, player grid, hero stats, bottom nav, and shell clipping
- Align sidebar drawer breakpoint with the hamburger (`lg` / 992px)
- Make the drawer scrollable end-to-end; hide bottom nav while open
- Fix search icon positioning, player chip scroll, and error banner sizing on mobile
- Expand e2e coverage for menu open/close, horizontal overflow, and More menu anchoring

## Test plan
- [x] Open app at 390×844: hamburger opens drawer, Close/backdrop/Escape dismisses it, `ds-shell-ready` stays on `<html>`
- [x] More menu opens anchored to the right without stretching across the topbar
- [x] Dashboard / Games / Players / Teams / Stats show no horizontal page scroll (also verified at 320px)
- [x] Bottom nav remains usable and hides while the drawer is open
- [x] Desktop (≥992px) top nav still works; drawer stays hidden
- [x] `PLAYWRIGHT_SKIP_WEBSERVER=1 npx playwright test --grep "mobile|Navigation flow"` — 5 passed

## Screenshots
Captured under `/opt/cursor/artifacts/screenshots/` during verification (`mobile-home.png`, `mobile-home-menu-open.png`, `mobile-players.png`, `mobile-games.png`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9eb2-747a-7efa-85ee-dcfb10bbb6b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9eb2-747a-7efa-85ee-dcfb10bbb6b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

